### PR TITLE
Added option to throttle frame rate and trigger single images

### DIFF
--- a/include/rviz_camera_stream/camera_display.h
+++ b/include/rviz_camera_stream/camera_display.h
@@ -38,7 +38,7 @@
 #include <OgreSharedPtr.h>
 #include <OgreTexture.h>
 
-#include <sensor_msgs/CameraInfo.h>
+# include <sensor_msgs/CameraInfo.h>
 #include <std_srvs/Trigger.h>
 
 #include "rviz/image/image_display_base.h"
@@ -109,16 +109,11 @@ private:
   void unsubscribe();
 
   ros::ServiceServer trigger_service_;
-  bool triggerCallback(std_srvs::TriggerRequest& req,
-                       std_srvs::TriggerResponse& res)
-  {
-      trigger_activated_ = true;
-      res.success = true;
-      res.message = "New image was triggered";
-      return true;
-  }
-
+  bool triggerCallback(std_srvs::TriggerRequest& req, std_srvs::TriggerResponse& res);
   bool trigger_activated_;
+  float requested_framerate_;
+  ros::Time last_image_publication_time_;
+
   void caminfoCallback(const sensor_msgs::CameraInfo::ConstPtr& msg);
 
   bool updateCamera();

--- a/include/rviz_camera_stream/camera_display.h
+++ b/include/rviz_camera_stream/camera_display.h
@@ -103,6 +103,7 @@ private Q_SLOTS:
 
   void updateTopic();
   virtual void updateQueueSize();
+  virtual void updateFrameRate();
 
 private:
   void subscribe();
@@ -111,7 +112,6 @@ private:
   ros::ServiceServer trigger_service_;
   bool triggerCallback(std_srvs::TriggerRequest& req, std_srvs::TriggerResponse& res);
   bool trigger_activated_;
-  float requested_framerate_;
   ros::Time last_image_publication_time_;
 
   void caminfoCallback(const sensor_msgs::CameraInfo::ConstPtr& msg);
@@ -127,6 +127,7 @@ private:
   RosTopicProperty* camera_info_property_;
   DisplayGroupVisibilityProperty* visibility_property_;
   IntProperty* queue_size_property_;
+  FloatProperty* frame_rate_property_;
 
   sensor_msgs::CameraInfo::ConstPtr current_caminfo_;
   boost::mutex caminfo_mutex_;

--- a/include/rviz_camera_stream/camera_display.h
+++ b/include/rviz_camera_stream/camera_display.h
@@ -38,9 +38,10 @@
 #include <OgreSharedPtr.h>
 #include <OgreTexture.h>
 
-# include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/CameraInfo.h>
+#include <std_srvs/Trigger.h>
 
-# include "rviz/image/image_display_base.h"
+#include "rviz/image/image_display_base.h"
 #endif
 
 namespace Ogre
@@ -107,6 +108,17 @@ private:
   void subscribe();
   void unsubscribe();
 
+  ros::ServiceServer trigger_service_;
+  bool triggerCallback(std_srvs::TriggerRequest& req,
+                       std_srvs::TriggerResponse& res)
+  {
+      trigger_activated_ = true;
+      res.success = true;
+      res.message = "New image was triggered";
+      return true;
+  }
+
+  bool trigger_activated_;
   void caminfoCallback(const sensor_msgs::CameraInfo::ConstPtr& msg);
 
   bool updateCamera();

--- a/include/rviz_camera_stream/camera_display.h
+++ b/include/rviz_camera_stream/camera_display.h
@@ -39,9 +39,9 @@
 #include <OgreTexture.h>
 
 # include <sensor_msgs/CameraInfo.h>
+# include "rviz/image/image_display_base.h"
 #include <std_srvs/Trigger.h>
 
-#include "rviz/image/image_display_base.h"
 #endif
 
 namespace Ogre

--- a/src/camera_display.cpp
+++ b/src/camera_display.cpp
@@ -259,7 +259,7 @@ void CameraPub::preRenderTargetUpdate(const Ogre::RenderTargetEvent& evt)
 void CameraPub::postRenderTargetUpdate(const Ogre::RenderTargetEvent& evt)
 {
   // Publish the rendered window video stream
-  float framerate = 2;
+  float framerate = -1;
   ros::param::get("/rviz_camera_framerate", framerate); /// Absolute name as RVIZ is started anonymously and other nodes need a fixed name
   ros::param::set("/rviz_camera_framerate", framerate); // make sure that parameter is shown in rosparam list
 


### PR DESCRIPTION
Added ability to throttle framerate using a parameter /rviz_camera_framerate 
(Absolute name as RVIZ is started anonymously and other nodes need a fixed name).
If framerate is set to 0, no images are published.

It is also possible to trigger a single image by sending
 a std_srvs/Trigger on /rviz_camera_trigger.